### PR TITLE
Express progress bar eta in minutes/seconds.

### DIFF
--- a/build/widgets/progress.js
+++ b/build/widgets/progress.js
@@ -1,8 +1,12 @@
-var CARRIAGE_RETURN, Progress, ProgressBarFormatter, _;
+var CARRIAGE_RETURN, Progress, ProgressBarFormatter, moment, _;
 
 _ = require('lodash');
 
 _.str = require('underscore.string');
+
+moment = require('moment');
+
+require('moment-duration-format');
 
 ProgressBarFormatter = require('progress-bar-formatter');
 
@@ -18,7 +22,7 @@ module.exports = Progress = (function() {
       incomplete: ' ',
       length: size
     });
-    this.format = "" + message + " [<%= bar %>] <%= percentage %>% eta <%= eta %>s";
+    this.format = "" + message + " [<%= bar %>] <%= percentage %>% eta <%= eta %>";
   }
 
   Progress.prototype.tick = function(state) {
@@ -31,7 +35,7 @@ module.exports = Progress = (function() {
     this.lastLine = _.template(this.format, {
       bar: this.bar.format(state.percentage / 100),
       percentage: Math.floor(state.percentage),
-      eta: state.eta
+      eta: moment.duration(state.eta, 'seconds').format('m[m]ss[s]')
     });
     return this.lastLine;
   };

--- a/lib/widgets/progress.coffee
+++ b/lib/widgets/progress.coffee
@@ -1,5 +1,7 @@
 _ = require('lodash')
 _.str = require('underscore.string')
+moment = require('moment')
+require('moment-duration-format')
 ProgressBarFormatter = require('progress-bar-formatter')
 
 CARRIAGE_RETURN = '\u001b[1A'
@@ -15,7 +17,7 @@ module.exports = class Progress
 			incomplete: ' '
 			length: size
 
-		@format = "#{message} [<%= bar %>] <%= percentage %>% eta <%= eta %>s"
+		@format = "#{message} [<%= bar %>] <%= percentage %>% eta <%= eta %>"
 
 	tick: (state) ->
 
@@ -28,7 +30,7 @@ module.exports = class Progress
 		@lastLine = _.template @format,
 			bar: @bar.format(state.percentage / 100)
 			percentage: Math.floor(state.percentage)
-			eta: state.eta
+			eta: moment.duration(state.eta, 'seconds').format('m[m]ss[s]')
 
 		return @lastLine
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "inquirer": "^0.8.0",
     "lodash": "~2.4.1",
     "lodash-contrib": "^241.4.14",
+    "moment": "^2.10.3",
+    "moment-duration-format": "^1.3.0",
     "progress-bar-formatter": "^2.0.1",
     "resin-sdk": "^1.8.0",
     "underscore.string": "^2.4.0"


### PR DESCRIPTION
<img width="371" alt="screenshot 2015-07-09 12 27 48" src="https://cloud.githubusercontent.com/assets/2192773/8600833/21c8332c-2636-11e5-80c8-57403767a9c6.png">
