### PR TITLE
Implement drive widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Documentation
   * [.table](#visuals.table) : <code>object</code>
     * [.horizontal(data, ordering)](#visuals.table.horizontal)
     * [.vertical(data, ordering)](#visuals.table.vertical)
+  * [.drive()](#visuals.drive) ⇒ <code>Promise.&lt;String&gt;</code>
 
 <a name="visuals.Progress"></a>
 ### visuals.Progress
@@ -202,6 +203,19 @@ AGE:       40
 
 == EXTRAS
 JOB:       Developer
+```
+<a name="visuals.drive"></a>
+### visuals.drive() ⇒ <code>Promise.&lt;String&gt;</code>
+Currently, this function only checks the drive list once. In the future, the dropdown will detect and autorefresh itself when the drive list changes.
+
+**Kind**: static method of <code>[visuals](#visuals)</code>  
+**Summary**: Prompt the user to select a drive device  
+**Returns**: <code>Promise.&lt;String&gt;</code> - device path  
+**Access:** public  
+**Example**  
+```js
+visuals.drive().then (drive) ->
+	console.log(drive)
 ```
 
 Support

--- a/build/visuals.js
+++ b/build/visuals.js
@@ -29,5 +29,6 @@ THE SOFTWARE.
 module.exports = {
   Progress: require('./widgets/progress'),
   Spinner: require('./widgets/spinner'),
-  table: require('./widgets/table')
+  table: require('./widgets/table'),
+  drive: require('./widgets/drive')
 };

--- a/build/widgets/drive.js
+++ b/build/widgets/drive.js
@@ -1,0 +1,82 @@
+
+/*
+The MIT License
+
+Copyright (c) 2015 Resin.io, Inc. https://resin.io.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+ */
+var Promise, _, async, drivelist, form, getDrives;
+
+_ = require('lodash');
+
+async = require('async');
+
+Promise = require('bluebird');
+
+drivelist = Promise.promisifyAll(require('drivelist'));
+
+form = require('resin-cli-form');
+
+getDrives = function() {
+  return drivelist.listAsync().then(function(drives) {
+    return Promise.fromNode(function(callback) {
+      return async.reject(drives, drivelist.isSystem, function(results) {
+        return callback(null, results);
+      });
+    });
+  });
+};
+
+
+/**
+ * @summary Prompt the user to select a drive device
+ * @name visuals.drive
+ * @function
+ * @public
+ * @memberof visuals
+ *
+ * @description
+ * Currently, this function only checks the drive list once. In the future, the dropdown will detect and autorefresh itself when the drive list changes.
+ *
+ * @returns {Promise<String>} device path
+ *
+ * @example
+ * visuals.drive().then (drive) ->
+ * 	console.log(drive)
+ */
+
+module.exports = function() {
+  return getDrives().then(function(drives) {
+    if (_.isEmpty(drives)) {
+      throw new Error('No available drives');
+    }
+    return form.ask({
+      type: 'list',
+      name: 'drive',
+      message: 'Select a drive',
+      choices: _.map(drives, function(drive) {
+        return {
+          name: drive.device + " (" + drive.size + ") - " + drive.description,
+          value: drive.device
+        };
+      })
+    });
+  });
+};

--- a/coffeelint.json
+++ b/coffeelint.json
@@ -20,7 +20,7 @@
         "name": "max_line_length",
         "value": 120,
         "level": "error",
-        "limitComments": true
+        "limitComments": false
     },
     "line_endings": {
         "name": "line_endings",

--- a/package.json
+++ b/package.json
@@ -37,12 +37,16 @@
     "mochainon": "^1.0.0"
   },
   "dependencies": {
+    "async": "^1.4.0",
+    "bluebird": "^2.9.34",
     "cli-spinner": "^0.2.1",
     "columnify": "^1.5.1",
+    "drivelist": "^1.2.2",
     "lodash": "^3.10.0",
     "moment": "^2.10.3",
     "moment-duration-format": "^1.3.0",
     "progress-bar-formatter": "^2.0.1",
+    "resin-cli-form": "^1.1.0",
     "underscore.string": "^3.1.1"
   }
 }

--- a/tests/widgets/drive.spec.coffee
+++ b/tests/widgets/drive.spec.coffee
@@ -1,0 +1,19 @@
+m = require('mochainon')
+drivelist = require('drivelist')
+drive = require('../../lib/widgets/drive')
+
+describe 'Drive:', ->
+
+	describe '.drive()', ->
+
+		describe 'given no drives', ->
+
+			beforeEach ->
+				@drivelistListStub = m.sinon.stub(drivelist, 'list')
+				@drivelistListStub.yields(null, [])
+
+			afterEach ->
+				@drivelistListStub.restore()
+
+			it 'should be rejected with an error', ->
+				m.chai.expect(drive()).to.be.rejectedWith('No available drives')


### PR DESCRIPTION
This widget takes care of scanning the system for available drives
(omitting system drives that can cause major harm to the host if
 written).

For now, the widget scans just a single time, but will later be extended
to auto refresh in an interval to detect new connected devices in real
time.

The interaction of this widget is not tested at the moment, due to
issues simulating key presses on cases where stdin was not attached to
the process (CI servers, like Travis and Appveyor).
