### PR TITLE
Right-trim all rows from horizontal & vertical tables

### DIFF
--- a/build/widgets/table.js
+++ b/build/widgets/table.js
@@ -22,7 +22,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
  */
-var _, applySubtitles, columnify, getAlias, normalizeSubtitle, normalizeTitle, parseOrdering;
+var _, applySubtitles, columnify, getAlias, normalizeSubtitle, normalizeTitle, parseOrdering, trimRight;
 
 _ = require('lodash');
 
@@ -91,6 +91,15 @@ applySubtitles = function(table, ordering) {
   return titleizedTable.join('\n');
 };
 
+trimRight = function(table) {
+  var splitTable;
+  splitTable = _.str.lines(table);
+  splitTable = _.map(splitTable, function(row) {
+    return _.str.rtrim(row);
+  });
+  return splitTable.join('\n');
+};
+
 
 /**
  * @summary Make an horizontal table
@@ -123,13 +132,13 @@ exports.horizontal = function(data, ordering) {
     return;
   }
   ordering = parseOrdering(ordering, data);
-  return columnify(data, {
+  return trimRight(columnify(data, {
     columns: _.pluck(ordering, 'name'),
     preserveNewLines: true,
     headingTransform: function(heading) {
       return normalizeTitle(getAlias(ordering, heading) || heading);
     }
-  });
+  }));
 };
 
 
@@ -200,5 +209,5 @@ exports.vertical = function(data, ordering) {
     columns: ['property', 'value'],
     preserveNewLines: true
   });
-  return applySubtitles(table, ordering);
+  return trimRight(applySubtitles(table, ordering));
 };

--- a/lib/widgets/table.coffee
+++ b/lib/widgets/table.coffee
@@ -77,6 +77,12 @@ applySubtitles = (table, ordering) ->
 
 	return titleizedTable.join('\n')
 
+trimRight = (table) ->
+	splitTable = _.str.lines(table)
+	splitTable = _.map splitTable, (row) ->
+		return _.str.rtrim(row)
+	return splitTable.join('\n')
+
 ###*
 # @summary Make an horizontal table
 # @name visuals.table.horizontal
@@ -107,7 +113,7 @@ exports.horizontal = (data, ordering) ->
 
 	ordering = parseOrdering(ordering, data)
 
-	return columnify data,
+	return trimRight columnify data,
 		columns: _.pluck(ordering, 'name')
 		preserveNewLines: true
 		headingTransform: (heading) ->
@@ -186,4 +192,4 @@ exports.vertical = (data, ordering) ->
 		columns: [ 'property', 'value' ]
 		preserveNewLines: true
 
-	return applySubtitles(table, ordering)
+	return trimRight(applySubtitles(table, ordering))

--- a/tests/widgets/table.spec.coffee
+++ b/tests/widgets/table.spec.coffee
@@ -21,7 +21,7 @@ describe 'Table:', ->
 			], [ 'job', 'age', 'name' ]
 
 			m.chai.expect(output).to.equal [
-				'JOB       AGE NAME    '
+				'JOB       AGE NAME'
 				'Developer 40  John Doe'
 				'Designer  30  Jane Doe'
 			].join('\n')
@@ -38,11 +38,11 @@ describe 'Table:', ->
 			], [ 'name', 'age', 'job' ]
 
 			m.chai.expect(output).to.equal [
-				'NAME     AGE JOB      '
+				'NAME     AGE JOB'
 				'John Doe 40  Developer'
-				'             Musician '
-				'Jane Doe 30  Designer '
-				'             Actress  '
+				'             Musician'
+				'Jane Doe 30  Designer'
+				'             Actress'
 			].join('\n')
 
 		it 'should remove underscores from titles', ->
@@ -56,8 +56,8 @@ describe 'Table:', ->
 
 			m.chai.expect(output).to.equal [
 				'FIRST NAME LAST NAME'
-				'John       Doe      '
-				'Jane       Doe      '
+				'John       Doe'
+				'Jane       Doe'
 			].join('\n')
 
 		it 'should handle camel case titles', ->
@@ -71,8 +71,8 @@ describe 'Table:', ->
 
 			m.chai.expect(output).to.equal [
 				'FIRST NAME LAST NAME'
-				'John       Doe      '
-				'Jane       Doe      '
+				'John       Doe'
+				'Jane       Doe'
 			].join('\n')
 
 		it 'should print all data if no ordering', ->
@@ -87,9 +87,9 @@ describe 'Table:', ->
 			]
 
 			m.chai.expect(output).to.equal [
-				'NAME     AGE JOB      '
+				'NAME     AGE JOB'
 				'John Doe 40  Developer'
-				'Jane Doe 30  Designer '
+				'Jane Doe 30  Designer'
 			].join('\n')
 
 		it 'should be able to dynamically rename columns', ->
@@ -109,8 +109,8 @@ describe 'Table:', ->
 
 			m.chai.expect(output).to.equal [
 				'THE NAME HOW OLD? LIFE REASON'
-				'John Doe 40       Developer  '
-				'Jane Doe 30       Designer   '
+				'John Doe 40       Developer'
+				'Jane Doe 30       Designer'
 			].join('\n')
 
 	describe '.vertical()', ->
@@ -123,8 +123,8 @@ describe 'Table:', ->
 			, [ 'name', 'age', 'job' ]
 
 			m.chai.expect(output).to.equal [
-				'NAME: John Doe '
-				'AGE:  40       '
+				'NAME: John Doe'
+				'AGE:  40'
 				'JOB:  Developer'
 			].join('\n')
 
@@ -136,9 +136,9 @@ describe 'Table:', ->
 			, [ 'age', 'job', 'name' ]
 
 			m.chai.expect(output).to.equal [
-				'AGE:  40       '
+				'AGE:  40'
 				'JOB:  Developer'
-				'NAME: John Doe '
+				'NAME: John Doe'
 			].join('\n')
 
 		it 'should preserve new lines', ->
@@ -149,10 +149,10 @@ describe 'Table:', ->
 			, [ 'name', 'age', 'job' ]
 
 			m.chai.expect(output).to.equal [
-				'NAME: John Doe '
-				'AGE:  40       '
+				'NAME: John Doe'
+				'AGE:  40'
 				'JOB:  Developer'
-				'      Musician '
+				'      Musician'
 			].join('\n')
 
 		it 'should remove underscores from titles', ->
@@ -163,7 +163,7 @@ describe 'Table:', ->
 
 			m.chai.expect(output).to.equal [
 				'FIRST NAME: John'
-				'LAST NAME:  Doe '
+				'LAST NAME:  Doe'
 			].join('\n')
 
 		it 'should handle camel case titles', ->
@@ -174,7 +174,7 @@ describe 'Table:', ->
 
 			m.chai.expect(output).to.equal [
 				'FIRST NAME: John'
-				'LAST NAME:  Doe '
+				'LAST NAME:  Doe'
 			].join('\n')
 
 		it 'should print all data if no ordering', ->
@@ -184,8 +184,8 @@ describe 'Table:', ->
 				job: 'Developer'
 
 			m.chai.expect(output).to.equal [
-				'NAME: John Doe '
-				'AGE:  40       '
+				'NAME: John Doe'
+				'AGE:  40'
 				'JOB:  Developer'
 			].join('\n')
 
@@ -201,8 +201,8 @@ describe 'Table:', ->
 			]
 
 			m.chai.expect(output).to.equal [
-				'THE NAME:    John Doe '
-				'HOW OLD?:    40       '
+				'THE NAME:    John Doe'
+				'HOW OLD?:    40'
 				'LIFE REASON: Developer'
 			].join('\n')
 
@@ -221,11 +221,11 @@ describe 'Table:', ->
 			]
 
 			m.chai.expect(output).to.equal [
-				'NAME:  John Doe '
-				'AGE:   40       '
-				'                '
+				'NAME:  John Doe'
+				'AGE:   40'
+				''
 				'JOB:   Developer'
-				'HOBBY: Musician '
+				'HOBBY: Musician'
 			].join('\n')
 
 		it 'should support separators as null', ->
@@ -243,11 +243,11 @@ describe 'Table:', ->
 			]
 
 			m.chai.expect(output).to.equal [
-				'NAME:  John Doe '
-				'AGE:   40       '
-				'                '
+				'NAME:  John Doe'
+				'AGE:   40'
+				''
 				'JOB:   Developer'
-				'HOBBY: Musician '
+				'HOBBY: Musician'
 			].join('\n')
 
 		it 'should support separators as blank strings', ->
@@ -265,11 +265,11 @@ describe 'Table:', ->
 			]
 
 			m.chai.expect(output).to.equal [
-				'NAME:  John Doe '
-				'AGE:   40       '
-				'                '
+				'NAME:  John Doe'
+				'AGE:   40'
+				''
 				'JOB:   Developer'
-				'HOBBY: Musician '
+				'HOBBY: Musician'
 			].join('\n')
 
 		it 'should support multiple separators', ->
@@ -289,13 +289,13 @@ describe 'Table:', ->
 			]
 
 			m.chai.expect(output).to.equal [
-				'NAME:  John Doe '
-				'                '
-				'AGE:   40       '
-				'                '
+				'NAME:  John Doe'
+				''
+				'AGE:   40'
+				''
 				'JOB:   Developer'
-				'                '
-				'HOBBY: Musician '
+				''
+				'HOBBY: Musician'
 			].join('\n')
 
 		it 'should support group subtitles', ->
@@ -315,13 +315,13 @@ describe 'Table:', ->
 			]
 
 			m.chai.expect(output).to.equal [
-				'== SUMMARY      '
-				'NAME:  John Doe '
-				'AGE:   40       '
-				'                '
-				'== EXTRAS       '
+				'== SUMMARY'
+				'NAME:  John Doe'
+				'AGE:   40'
+				''
+				'== EXTRAS'
 				'JOB:   Developer'
-				'HOBBY: Musician '
+				'HOBBY: Musician'
 			].join('\n')
 
 		it 'should support multi word group subtitles', ->
@@ -338,5 +338,5 @@ describe 'Table:', ->
 			m.chai.expect(output).to.equal [
 				'== PERSON SHORT SUMMARY'
 				'NAME: John Doe'
-				'AGE:  40      '
+				'AGE:  40'
 			].join('\n')


### PR DESCRIPTION
Currently, blank space was added at the right of each row so that all
rows have an equal length. Consider the following example with explicit
quotes:

```
'NAME     JOB                     '
'John Doe Mobile Software Engineer'
'Jane Doe Lawyer                  '
```

Now consider that the terminal where this table is printed is not wide
enough to be able to display the second line completely.

Ideally, the long line will wrap to the line below, like this:

```
'NAME     JOB            '
'John Doe Mobile Software'
Engineer                 '
'Jane Doe Lawyer         '
```

However, notice that spaces are added at the right of each row so that
all have the same length, therefore is one of the rows doesn't fit in
the terminal, neither of them do. This results in whitespace wrapping to
the line below as well, causing something like:

```
'NAME     JOB            '
'       '
'John Doe Mobile Software'
Engineer'
'Jane Doe Lawyer         '
'       '
```

Which makes the table layout look completely broken.

The solution is to right-trim all the rows of the table, so only the
longest lines wrap, while the rest remain intact.

Notice that is important to not trim from the left as well, since we
support multiple-line values in the tables, for example:

```
'NAME     AGE JOB'
'John Doe 40  Developer'
'             Musician'
'Jane Doe 30  Designer'
'             Actress'
```

Trimming from the left as well will not lead to the desired result:

```
'NAME     AGE JOB'
'John Doe 40  Developer'
'Musician'
'Jane Doe 30  Designer'
'Actress'
```

Fixes: https://github.com/resin-io/resin-cli-visuals/issues/18
