### PR TITLE
Accept a message in visuals.drive()

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Documentation
   * [.table](#visuals.table) : <code>object</code>
     * [.horizontal(data, ordering)](#visuals.table.horizontal)
     * [.vertical(data, ordering)](#visuals.table.vertical)
-  * [.drive()](#visuals.drive) ⇒ <code>Promise.&lt;String&gt;</code>
+  * [.drive([message])](#visuals.drive) ⇒ <code>Promise.&lt;String&gt;</code>
 
 <a name="visuals.Progress"></a>
 ### visuals.Progress
@@ -205,16 +205,21 @@ AGE:       40
 JOB:       Developer
 ```
 <a name="visuals.drive"></a>
-### visuals.drive() ⇒ <code>Promise.&lt;String&gt;</code>
+### visuals.drive([message]) ⇒ <code>Promise.&lt;String&gt;</code>
 Currently, this function only checks the drive list once. In the future, the dropdown will detect and autorefresh itself when the drive list changes.
 
 **Kind**: static method of <code>[visuals](#visuals)</code>  
 **Summary**: Prompt the user to select a drive device  
 **Returns**: <code>Promise.&lt;String&gt;</code> - device path  
 **Access:** public  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| [message] | <code>String</code> | <code>&#x27;Select a drive&#x27;</code> | message |
+
 **Example**  
 ```js
-visuals.drive().then (drive) ->
+visuals.drive('Please select a drive').then (drive) ->
 	console.log(drive)
 ```
 

--- a/build/widgets/drive.js
+++ b/build/widgets/drive.js
@@ -55,14 +55,18 @@ getDrives = function() {
  * @description
  * Currently, this function only checks the drive list once. In the future, the dropdown will detect and autorefresh itself when the drive list changes.
  *
+ * @param {String} [message='Select a drive'] - message
  * @returns {Promise<String>} device path
  *
  * @example
- * visuals.drive().then (drive) ->
+ * visuals.drive('Please select a drive').then (drive) ->
  * 	console.log(drive)
  */
 
-module.exports = function() {
+module.exports = function(message) {
+  if (message == null) {
+    message = 'Select a drive';
+  }
   return getDrives().then(function(drives) {
     if (_.isEmpty(drives)) {
       throw new Error('No available drives');
@@ -70,7 +74,7 @@ module.exports = function() {
     return form.ask({
       type: 'list',
       name: 'drive',
-      message: 'Select a drive',
+      message: message,
       choices: _.map(drives, function(drive) {
         return {
           name: drive.device + " (" + drive.size + ") - " + drive.description,

--- a/lib/widgets/drive.coffee
+++ b/lib/widgets/drive.coffee
@@ -44,13 +44,14 @@ getDrives = ->
 # @description
 # Currently, this function only checks the drive list once. In the future, the dropdown will detect and autorefresh itself when the drive list changes.
 #
+# @param {String} [message='Select a drive'] - message
 # @returns {Promise<String>} device path
 #
 # @example
-# visuals.drive().then (drive) ->
+# visuals.drive('Please select a drive').then (drive) ->
 # 	console.log(drive)
 ###
-module.exports = ->
+module.exports = (message = 'Select a drive') ->
 	getDrives().then (drives) ->
 
 		if _.isEmpty(drives)
@@ -59,7 +60,7 @@ module.exports = ->
 		form.ask
 			type: 'list'
 			name: 'drive'
-			message: 'Select a drive'
+			message: message
 			choices: _.map drives, (drive) ->
 				return {
 					name: "#{drive.device} (#{drive.size}) - #{drive.description}"


### PR DESCRIPTION
This widget was locked to `Select a drive`.

The user can now pass a custom message.

The main motivation for this change in that CLI Form will support
passing a `drive` question, and as the other inputs, it accepts a
`message` property as well.
