### PR TITLE
Implement drive widget confirmation

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ JOB:       Developer
 ### visuals.drive([message]) ⇒ <code>Promise.&lt;String&gt;</code>
 Currently, this function only checks the drive list once. In the future, the dropdown will detect and autorefresh itself when the drive list changes.
 
+This widget automatically prompts for confirmation, and rejects with an error message if not confirmed.
+
 **Kind**: static method of <code>[visuals](#visuals)</code>  
 **Summary**: Prompt the user to select a drive device  
 **Returns**: <code>Promise.&lt;String&gt;</code> - device path  

--- a/build/widgets/drive.js
+++ b/build/widgets/drive.js
@@ -55,6 +55,8 @@ getDrives = function() {
  * @description
  * Currently, this function only checks the drive list once. In the future, the dropdown will detect and autorefresh itself when the drive list changes.
  *
+ * This widget automatically prompts for confirmation, and rejects with an error message if not confirmed.
+ *
  * @param {String} [message='Select a drive'] - message
  * @returns {Promise<String>} device path
  *
@@ -82,5 +84,15 @@ module.exports = function(message) {
         };
       })
     });
+  }).then(function(drive) {
+    return form.ask({
+      type: 'confirm',
+      "default": false,
+      message: "This will completely erase " + drive + ". Are you sure you want to continue?"
+    }).tap(function(confirmation) {
+      if (!confirmation) {
+        throw new Error('Aborted');
+      }
+    })["return"](drive);
   });
 };

--- a/lib/widgets/drive.coffee
+++ b/lib/widgets/drive.coffee
@@ -44,6 +44,8 @@ getDrives = ->
 # @description
 # Currently, this function only checks the drive list once. In the future, the dropdown will detect and autorefresh itself when the drive list changes.
 #
+# This widget automatically prompts for confirmation, and rejects with an error message if not confirmed.
+#
 # @param {String} [message='Select a drive'] - message
 # @returns {Promise<String>} device path
 #
@@ -66,3 +68,12 @@ module.exports = (message = 'Select a drive') ->
 					name: "#{drive.device} (#{drive.size}) - #{drive.description}"
 					value: drive.device
 				}
+
+	.then (drive) ->
+		form.ask
+			type: 'confirm'
+			default: false
+			message: "This will completely erase #{drive}. Are you sure you want to continue?"
+		.tap (confirmation) ->
+			throw new Error('Aborted') if not confirmation
+		.return(drive)


### PR DESCRIPTION
Drive widget now automatically prompts for confirmation.

If confirmation is not accepted, the promise rejects with an error
message.
