### PR TITLE
Fix Spinner memory leak when calling start() multiple times

### DIFF
--- a/build/widgets/spinner.js
+++ b/build/widgets/spinner.js
@@ -54,6 +54,7 @@ module.exports = Spinner = (function() {
     this.spinner = new CliSpinner("%s " + message);
     this.spinner.setSpinnerString('|/-\\');
     this.spinner.setSpinnerDelay(60);
+    this.started = false;
   }
 
 
@@ -69,7 +70,11 @@ module.exports = Spinner = (function() {
    */
 
   Spinner.prototype.start = function() {
-    return this.spinner.start();
+    if (this.started) {
+      return;
+    }
+    this.spinner.start();
+    return this.started = true;
   };
 
 
@@ -85,7 +90,11 @@ module.exports = Spinner = (function() {
    */
 
   Spinner.prototype.stop = function() {
-    return this.spinner.stop(true);
+    if (!this.started) {
+      return;
+    }
+    this.spinner.stop(true);
+    return this.started = false;
   };
 
   return Spinner;

--- a/lib/widgets/spinner.coffee
+++ b/lib/widgets/spinner.coffee
@@ -55,6 +55,8 @@ module.exports = class Spinner
 		@spinner.setSpinnerString('|/-\\')
 		@spinner.setSpinnerDelay(60)
 
+		@started = false
+
 	###*
 	# @summary Start the spinner
 	# @name visuals.Spinner#start
@@ -66,7 +68,9 @@ module.exports = class Spinner
 	# spinner.start()
 	###
 	start: ->
+		return if @started
 		@spinner.start()
+		@started = true
 
 	###*
 	# @summary Stop the spinner
@@ -79,4 +83,6 @@ module.exports = class Spinner
 	# spinner.stop()
 	###
 	stop: ->
+		return if not @started
 		@spinner.stop(true)
+		@started = false


### PR DESCRIPTION
Calling `#start()` multiple times caused multiple spinner instances to
be allocated.
