### PR TITLE
Assume eta to be zero if it doesn't exist

### DIFF
--- a/build/widgets/progress.js
+++ b/build/widgets/progress.js
@@ -92,13 +92,10 @@ module.exports = Progress = (function() {
     if (state.percentage == null) {
       throw new Error('Missing percentage');
     }
-    if (state.eta == null) {
-      throw new Error('Missing eta');
-    }
     data = {
       bar: this._bar.format(state.percentage / 100),
       percentage: Math.floor(state.percentage),
-      eta: moment.duration(state.eta, 'seconds').format('m[m]ss[s]')
+      eta: moment.duration(state.eta || 0, 'seconds').format('m[m]ss[s]')
     };
     this._lastLine = _.template(this._format)(data);
     return this._lastLine;

--- a/lib/widgets/progress.coffee
+++ b/lib/widgets/progress.coffee
@@ -86,13 +86,10 @@ module.exports = class Progress
 		if not state.percentage?
 			throw new Error('Missing percentage')
 
-		if not state.eta?
-			throw new Error('Missing eta')
-
 		data =
 			bar: @_bar.format(state.percentage / 100)
 			percentage: Math.floor(state.percentage)
-			eta: moment.duration(state.eta, 'seconds').format('m[m]ss[s]')
+			eta: moment.duration(state.eta or 0, 'seconds').format('m[m]ss[s]')
 
 		@_lastLine = _.template(@_format)(data)
 

--- a/tests/widgets/progress.spec.coffee
+++ b/tests/widgets/progress.spec.coffee
@@ -36,10 +36,12 @@ describe 'Progress:', ->
 						@progress.update(eta: 300)
 					.to.throw('Missing percentage')
 
-				it 'should throw if no eta', ->
-					m.chai.expect =>
-						@progress.update(percentage: 50)
-					.to.throw('Missing eta')
+				it 'should assume 0 if no eta', ->
+					m.chai.expect(@stdout.data).to.equal('')
+					@progress.update(percentage: 20)
+
+					progress = '\n\u001b[1Afoo [=====                   ] 20% eta 0s\n'
+					m.chai.expect(@stdout.data).to.equal(progress)
 
 				it 'should print a progress bar with no progress', ->
 					m.chai.expect(@stdout.data).to.equal('')


### PR DESCRIPTION
Currently, the progress bar throws an error if no eta, however we can
safely assume zero and move on.
