### PR TITLE
Run build tasks in sequence

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -4,6 +4,7 @@ mocha = require('gulp-mocha')
 gutil = require('gulp-util')
 coffeelint = require('gulp-coffeelint')
 coffee = require('gulp-coffee')
+sequence = require('gulp-sequence')
 
 OPTIONS =
 	config:
@@ -31,11 +32,7 @@ gulp.task 'lint', ->
 		}))
 		.pipe(coffeelint.reporter())
 
-gulp.task 'build', [
-	'lint'
-	'test'
-	'coffee'
-]
+gulp.task('build', sequence('lint', 'test', 'coffee'))
 
 gulp.task 'watch', [ 'build' ], ->
 	gulp.watch([ OPTIONS.files.coffee ], [ 'build' ])

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gulp-coffee": "^2.3.1",
     "gulp-coffeelint": "^0.5.0",
     "gulp-mocha": "^2.1.3",
+    "gulp-sequence": "^0.4.1",
     "gulp-util": "~3.0.1",
     "jsdoc-to-markdown": "^1.1.1",
     "mocha": "^2.2.5",


### PR DESCRIPTION
We set `gulp build` as the `prepublish` script in `package.json`. This
means that when running `npm install`, the task will be ran.

Given that we use stdout interceptors in the Progress widget unit tests,
there are some cases where the tests fail for the following reason:
- All tasks in `gulp build` run parallel, therefore sometimes another
  task finishes when `gulp test` is still running, interfering with stdout
  mocking.

The solution is to run the tasks in `build` sequentially.
