### PR TITLE
Prevent drive submissions if no drives

### DIFF
--- a/build/widgets/drive/index.js
+++ b/build/widgets/drive/index.js
@@ -87,7 +87,7 @@ module.exports = function(message) {
     message = 'Select a drive';
   }
   return getDrives().then(function(drives) {
-    var list, options, render, scanner, ui;
+    var list, onSubmit, options, render, scanner, ui;
     options = {
       message: message,
       name: 'drives',
@@ -98,6 +98,13 @@ module.exports = function(message) {
       output: process.stdout
     });
     list = new InquirerList(options, ui.rl);
+    onSubmit = list.onSubmit;
+    list.onSubmit = function() {
+      if (list.opt.choices.length === 0) {
+        return;
+      }
+      return onSubmit.apply(list, arguments);
+    };
     render = list.render;
     list.render = function() {
       if (list.opt.choices.length === 0) {

--- a/lib/widgets/drive/index.coffee
+++ b/lib/widgets/drive/index.coffee
@@ -90,9 +90,17 @@ module.exports = (message = 'Select a drive') ->
 
 		list = new InquirerList(options, ui.rl)
 
+		list.isEmpty = ->
+			return list.opt.choices.length is 0
+
+		onSubmit = list.onSubmit
+		list.onSubmit = ->
+			return if list.isEmpty()
+			onSubmit.apply(list, arguments)
+
 		render = list.render
 		list.render = ->
-			if list.opt.choices.length is 0
+			if list.isEmpty()
 
 				# By using this.screen.render() the module
 				# knows how many lines to clean automatically.


### PR DESCRIPTION
Currently, if you press enter and there are no drives, the widget will
crash.
