### PR TITLE
Improve "No available drives" message

### DIFF
--- a/build/widgets/drive/index.js
+++ b/build/widgets/drive/index.js
@@ -22,9 +22,11 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
  */
-var DriveScanner, DynamicList, Promise, _, async, driveToChoice, drivelist, getDrives;
+var DriveScanner, DynamicList, Promise, _, async, chalk, driveToChoice, drivelist, getDrives;
 
 _ = require('lodash');
+
+chalk = require('chalk');
 
 async = require('async');
 
@@ -84,7 +86,7 @@ module.exports = function(message) {
     });
     list = new DynamicList({
       message: message,
-      emptyMessage: 'No available drives',
+      emptyMessage: (chalk.red('x')) + " No available drives, plug one!",
       choices: _.map(drives, driveToChoice)
     });
     scanner.on('add', function(drive) {

--- a/lib/widgets/drive/index.coffee
+++ b/lib/widgets/drive/index.coffee
@@ -23,6 +23,7 @@ THE SOFTWARE.
 ###
 
 _ = require('lodash')
+chalk = require('chalk')
 async = require('async')
 Promise = require('bluebird')
 drivelist = Promise.promisifyAll(require('drivelist'))
@@ -66,7 +67,7 @@ module.exports = (message = 'Select a drive') ->
 
 		list = new DynamicList
 			message: message
-			emptyMessage: 'No available drives'
+			emptyMessage: "#{chalk.red('x')} No available drives, plug one!"
 			choices: _.map(drives, driveToChoice)
 
 		scanner.on 'add', (drive) ->

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "async": "^1.4.0",
     "bluebird": "^2.9.34",
+    "chalk": "^1.1.1",
     "cli-spinner": "^0.2.1",
     "columnify": "^1.5.1",
     "drivelist": "^1.2.2",


### PR DESCRIPTION
- Invite the user to plug a drive, to give a clue that the widget will
  react in that scenario.
- Add a red `x` to be consistent with inquirer's style.
