### PR TITLE
Upgrade drivelist to v2.0.0

### DIFF
--- a/build/widgets/drive/index.js
+++ b/build/widgets/drive/index.js
@@ -22,13 +22,11 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
  */
-var DriveScanner, DynamicList, Promise, _, async, chalk, driveToChoice, drivelist, getDrives;
+var DriveScanner, DynamicList, Promise, _, chalk, driveToChoice, drivelist, getDrives;
 
 _ = require('lodash');
 
 chalk = require('chalk');
-
-async = require('async');
 
 Promise = require('bluebird');
 
@@ -47,10 +45,8 @@ driveToChoice = function(drive) {
 
 getDrives = function() {
   return drivelist.listAsync().then(function(drives) {
-    return Promise.fromNode(function(callback) {
-      return async.reject(drives, drivelist.isSystem, function(results) {
-        return callback(null, results);
-      });
+    return _.reject(drives, {
+      system: true
     });
   });
 };

--- a/lib/widgets/drive/index.coffee
+++ b/lib/widgets/drive/index.coffee
@@ -24,7 +24,6 @@ THE SOFTWARE.
 
 _ = require('lodash')
 chalk = require('chalk')
-async = require('async')
 Promise = require('bluebird')
 drivelist = Promise.promisifyAll(require('drivelist'))
 DriveScanner = require('./drive-scanner')
@@ -38,9 +37,7 @@ driveToChoice = (drive) ->
 
 getDrives = ->
 	drivelist.listAsync().then (drives) ->
-		Promise.fromNode (callback) ->
-			async.reject drives, drivelist.isSystem, (results) ->
-				return callback(null, results)
+		return _.reject(drives, system: true)
 
 ###*
 # @summary Prompt the user to select a drive device

--- a/package.json
+++ b/package.json
@@ -38,12 +38,11 @@
     "mochainon": "^1.0.0"
   },
   "dependencies": {
-    "async": "^1.4.0",
     "bluebird": "^2.9.34",
     "chalk": "^1.1.1",
     "cli-spinner": "^0.2.1",
     "columnify": "^1.5.1",
-    "drivelist": "^1.2.2",
+    "drivelist": "^2.0.0",
     "inquirer": "^0.10.0",
     "lodash": "^3.10.0",
     "moment": "^2.10.3",


### PR DESCRIPTION
- Simplify system drive filtering.
- Fix a bug that caused some OS X to not be detected.
