### PR TITLE
Upgrade inquirer to v0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "cli-spinner": "^0.2.1",
     "columnify": "^1.5.1",
     "drivelist": "^2.0.0",
-    "inquirer": "^0.10.0",
+    "inquirer": "^0.11.0",
     "inquirer-dynamic-list": "^1.0.0",
     "lodash": "^3.10.0",
     "moment": "^2.10.3",


### PR DESCRIPTION
This version contains a fix that prevents crashes when running in an
environment when the detected CLI width is 0.

See https://github.com/SBoudrias/Inquirer.js/commit/e565c98f81f8dfa814b675a416a89f93b6118c13
