### PR TITLE
Hide the ETA, if no ETA is specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Changed
+
+- Hide the progress ETA if not specified, rather than assuming it to be 0s
+
 ## [1.3.1] - 2017-05-10
 
 ### Changed

--- a/build/widgets/progress.js
+++ b/build/widgets/progress.js
@@ -49,12 +49,12 @@ module.exports = Progress = (function() {
     if (_.str.isBlank(message)) {
       throw new Error('Missing message');
     }
+    this._message = message;
     this._bar = new ProgressBarFormatter({
       complete: '=',
       incomplete: ' ',
       length: 24
     });
-    this._format = message + " [<%= bar %>] <%= percentage %>% eta <%= eta %>";
   }
 
 
@@ -80,16 +80,16 @@ module.exports = Progress = (function() {
    */
 
   Progress.prototype._tick = function(state) {
-    var data;
+    var bar, percentage;
     if (state.percentage == null) {
       throw new Error('Missing percentage');
     }
-    data = {
-      bar: this._bar.format(state.percentage / 100),
-      percentage: Math.floor(state.percentage),
-      eta: moment.duration(state.eta || 0, 'seconds').format('m[m]ss[s]')
-    };
-    this._lastLine = _.template(this._format)(data);
+    bar = this._bar.format(state.percentage / 100);
+    percentage = Math.floor(state.percentage);
+    this._lastLine = this._message + " [" + bar + "] " + percentage + "%";
+    if (state.eta != null) {
+      this._lastLine += " eta " + (moment.duration(state.eta, 'seconds').format('m[m]ss[s]'));
+    }
     return this._lastLine;
   };
 

--- a/lib/widgets/progress.coffee
+++ b/lib/widgets/progress.coffee
@@ -40,18 +40,16 @@ module.exports = class Progress
 	# progress = new visuals.Progress('Hello World')
 	###
 	constructor: (message) ->
-
 		if _.str.isBlank(message)
 			throw new Error('Missing message')
 
+		@_message = message
 		@_bar = new ProgressBarFormatter
 			complete: '='
 			incomplete: ' '
 
 			# Width of the progress bar
 			length: 24
-
-		@_format = "#{message} [<%= bar %>] <%= percentage %>% eta <%= eta %>"
 
 	###*
 	# @summary Get progress string from a state
@@ -78,12 +76,13 @@ module.exports = class Progress
 		if not state.percentage?
 			throw new Error('Missing percentage')
 
-		data =
-			bar: @_bar.format(state.percentage / 100)
-			percentage: Math.floor(state.percentage)
-			eta: moment.duration(state.eta or 0, 'seconds').format('m[m]ss[s]')
+		bar = @_bar.format(state.percentage / 100)
+		percentage = Math.floor(state.percentage)
 
-		@_lastLine = _.template(@_format)(data)
+		@_lastLine = "#{@_message} [#{bar}] #{percentage}%"
+
+		if state.eta?
+			@_lastLine += " eta #{moment.duration(state.eta, 'seconds').format('m[m]ss[s]')}"
 
 		return @_lastLine
 

--- a/tests/widgets/progress.spec.coffee
+++ b/tests/widgets/progress.spec.coffee
@@ -36,11 +36,11 @@ describe 'Progress:', ->
 						@progress.update(eta: 300)
 					.to.throw('Missing percentage')
 
-				it 'should assume 0 if no eta', ->
+				it 'should hide the eta if not specified', ->
 					m.chai.expect(@stdout.data).to.equal('')
 					@progress.update(percentage: 20)
 
-					progress = '\n\u001b[1Afoo [=====                   ] 20% eta 0s\n'
+					progress = '\n\u001b[1Afoo [=====                   ] 20%\n'
 					m.chai.expect(@stdout.data).to.equal(progress)
 
 				it 'should print a progress bar with no progress', ->


### PR DESCRIPTION
Connects to #42.

This behaviour isn't technically breaking, but does visually differ from previous behaviour, where the ETA was assumed to be 0s if not specified. You can explicitly pass 0 though, if you like, to get the previous output.

Some code might be expecting this behaviour but:
* It's a bit weird, and surely most cases you'd always pass in some estimate of your ETA, unless you don't have one
* The new behaviour isn't that bad for other cases anyway: if at 0s you stop showing an ETA, that's going to seem reasonable, and should be visible for < 1s anyway :smile:

This lets us use this in `resin deploy` in the CLI (which has no easily available ETA, so has implemented it's own progress bar from scratch), and that not only nicely avoids duplicating it, but also provides a lovely easy fix for https://github.com/resin-io/resin-cli/issues/539 (a bug with the other progress bar's implementation).