### PR TITLE
upgrade(package): Bump dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,69 @@ $ npm install --save resin-cli-visuals
 Documentation
 -------------
 
+## Classes
+
+<dl>
+<dt><a href="#DriveScanner">DriveScanner</a></dt>
+<dd></dd>
+</dl>
+
+## Objects
+
+<dl>
+<dt><a href="#visuals">visuals</a> : <code>object</code></dt>
+<dd></dd>
+</dl>
+
+<a name="DriveScanner"></a>
+
+## DriveScanner
+**Kind**: global class  
+**Summary**: Dynamically detect changes of connected drives  
+**Access**: protected  
+
+* [DriveScanner](#DriveScanner)
+    * [new DriveScanner(driveFinder, [options])](#new_DriveScanner_new)
+    * [.stop()](#DriveScanner+stop)
+
+<a name="new_DriveScanner_new"></a>
+
+### new DriveScanner(driveFinder, [options])
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| driveFinder | <code>function</code> |  | drive finder |
+| [options] | <code>Object</code> |  | scan options |
+| [options.interval] | <code>Number</code> | <code>1000</code> | interval |
+| [options.drives] | <code>Array.&lt;Object&gt;</code> |  | current drives |
+
+**Example**  
+```js
+scanner = new DriveScanner driveFinder,
+	interval: 1000
+	drives: [
+		{ foo: 'bar' }
+	]
+```
+<a name="DriveScanner+stop"></a>
+
+### driveScanner.stop()
+**Kind**: instance method of [<code>DriveScanner</code>](#DriveScanner)  
+**Summary**: Stop the interval  
+**Access**: public  
+**Example**  
+```js
+scanner = new DriveScanner(@driveFinder, interval: 1000)
+scanner.stop()
+```
 <a name="visuals"></a>
 
 ## visuals : <code>object</code>
 **Kind**: global namespace  
 
 * [visuals](#visuals) : <code>object</code>
+    * [.SpinnerPromise](#visuals.SpinnerPromise)
+        * [new SpinnerPromise(options)](#new_visuals.SpinnerPromise_new)
     * [.Spinner](#visuals.Spinner)
         * [new Spinner(message)](#new_visuals.Spinner_new)
         * [.start()](#visuals.Spinner+start)
@@ -40,116 +97,17 @@ Documentation
     * [.Progress](#visuals.Progress)
         * [new Progress(message)](#new_visuals.Progress_new)
         * [.update(state)](#visuals.Progress+update)
-    * [.SpinnerPromise](#visuals.SpinnerPromise)
-        * [new SpinnerPromise(options)](#new_visuals.SpinnerPromise_new)
     * [.table](#visuals.table) : <code>object</code>
         * [.horizontal(data, ordering)](#visuals.table.horizontal)
         * [.vertical(data, ordering)](#visuals.table.vertical)
     * [.drive([message])](#visuals.drive) ⇒ <code>Promise.&lt;String&gt;</code>
 
-<a name="visuals.Spinner"></a>
-
-### visuals.Spinner
-**Kind**: static class of <code>[visuals](#visuals)</code>  
-**Summary**: Create a CLI Spinner  
-**Access:** public  
-
-* [.Spinner](#visuals.Spinner)
-    * [new Spinner(message)](#new_visuals.Spinner_new)
-    * [.start()](#visuals.Spinner+start)
-    * [.stop()](#visuals.Spinner+stop)
-
-<a name="new_visuals.Spinner_new"></a>
-
-#### new Spinner(message)
-**Returns**: <code>Spinner</code> - spinner instance  
-**Throws**:
-
-- Will throw if no message.
-
-
-| Param | Type | Description |
-| --- | --- | --- |
-| message | <code>String</code> | message |
-
-**Example**  
-```js
-spinner = new visuals.Spinner('Hello World')
-```
-<a name="visuals.Spinner+start"></a>
-
-#### spinner.start()
-**Kind**: instance method of <code>[Spinner](#visuals.Spinner)</code>  
-**Summary**: Start the spinner  
-**Access:** public  
-**Example**  
-```js
-spinner = new visuals.Spinner('Hello World')
-spinner.start()
-```
-<a name="visuals.Spinner+stop"></a>
-
-#### spinner.stop()
-**Kind**: instance method of <code>[Spinner](#visuals.Spinner)</code>  
-**Summary**: Stop the spinner  
-**Access:** public  
-**Example**  
-```js
-spinner = new visuals.Spinner('Hello World')
-spinner.stop()
-```
-<a name="visuals.Progress"></a>
-
-### visuals.Progress
-**Kind**: static class of <code>[visuals](#visuals)</code>  
-**Summary**: Create a CLI Progress Bar  
-**Access:** public  
-
-* [.Progress](#visuals.Progress)
-    * [new Progress(message)](#new_visuals.Progress_new)
-    * [.update(state)](#visuals.Progress+update)
-
-<a name="new_visuals.Progress_new"></a>
-
-#### new Progress(message)
-**Returns**: <code>Progress</code> - progress bar instance  
-**Throws**:
-
-- Will throw if no message.
-
-
-| Param | Type | Description |
-| --- | --- | --- |
-| message | <code>String</code> | message |
-
-**Example**  
-```js
-progress = new visuals.Progress('Hello World')
-```
-<a name="visuals.Progress+update"></a>
-
-#### progress.update(state)
-**Kind**: instance method of <code>[Progress](#visuals.Progress)</code>  
-**Summary**: Update the progress bar  
-**Access:** public  
-
-| Param | Type | Description |
-| --- | --- | --- |
-| state | <code>Object</code> | progress state |
-| state.percentage | <code>Number</code> | percentage |
-| [state.eta] | <code>Number</code> | eta in seconds |
-
-**Example**  
-```js
-progress = new visuals.Progress('Hello World')
-progress.update(percentage: 49, eta: 300)
-```
 <a name="visuals.SpinnerPromise"></a>
 
 ### visuals.SpinnerPromise
-**Kind**: static class of <code>[visuals](#visuals)</code>  
+**Kind**: static class of [<code>visuals</code>](#visuals)  
 **Summary**: Create a CLI Spinner that spins on a promise  
-**Access:** public  
+**Access**: public  
 **Fulfil**: <code>Object</code> value - resolved or rejected promise  
 <a name="new_visuals.SpinnerPromise_new"></a>
 
@@ -176,10 +134,107 @@ visuals.SpinnerPromise
  .then (devices) ->
 		 console.log devices
 ```
+<a name="visuals.Spinner"></a>
+
+### visuals.Spinner
+**Kind**: static class of [<code>visuals</code>](#visuals)  
+**Summary**: Create a CLI Spinner  
+**Access**: public  
+
+* [.Spinner](#visuals.Spinner)
+    * [new Spinner(message)](#new_visuals.Spinner_new)
+    * [.start()](#visuals.Spinner+start)
+    * [.stop()](#visuals.Spinner+stop)
+
+<a name="new_visuals.Spinner_new"></a>
+
+#### new Spinner(message)
+**Returns**: <code>Spinner</code> - spinner instance  
+**Throws**:
+
+- Will throw if no message.
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| message | <code>String</code> | message |
+
+**Example**  
+```js
+spinner = new visuals.Spinner('Hello World')
+```
+<a name="visuals.Spinner+start"></a>
+
+#### spinner.start()
+**Kind**: instance method of [<code>Spinner</code>](#visuals.Spinner)  
+**Summary**: Start the spinner  
+**Access**: public  
+**Example**  
+```js
+spinner = new visuals.Spinner('Hello World')
+spinner.start()
+```
+<a name="visuals.Spinner+stop"></a>
+
+#### spinner.stop()
+**Kind**: instance method of [<code>Spinner</code>](#visuals.Spinner)  
+**Summary**: Stop the spinner  
+**Access**: public  
+**Example**  
+```js
+spinner = new visuals.Spinner('Hello World')
+spinner.stop()
+```
+<a name="visuals.Progress"></a>
+
+### visuals.Progress
+**Kind**: static class of [<code>visuals</code>](#visuals)  
+**Summary**: Create a CLI Progress Bar  
+**Access**: public  
+
+* [.Progress](#visuals.Progress)
+    * [new Progress(message)](#new_visuals.Progress_new)
+    * [.update(state)](#visuals.Progress+update)
+
+<a name="new_visuals.Progress_new"></a>
+
+#### new Progress(message)
+**Returns**: <code>Progress</code> - progress bar instance  
+**Throws**:
+
+- Will throw if no message.
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| message | <code>String</code> | message |
+
+**Example**  
+```js
+progress = new visuals.Progress('Hello World')
+```
+<a name="visuals.Progress+update"></a>
+
+#### progress.update(state)
+**Kind**: instance method of [<code>Progress</code>](#visuals.Progress)  
+**Summary**: Update the progress bar  
+**Access**: public  
+
+| Param | Type | Description |
+| --- | --- | --- |
+| state | <code>Object</code> | progress state |
+| state.percentage | <code>Number</code> | percentage |
+| [state.eta] | <code>Number</code> | eta in seconds |
+
+**Example**  
+```js
+progress = new visuals.Progress('Hello World')
+progress.update(percentage: 49, eta: 300)
+```
 <a name="visuals.table"></a>
 
 ### visuals.table : <code>object</code>
-**Kind**: static namespace of <code>[visuals](#visuals)</code>  
+**Kind**: static namespace of [<code>visuals</code>](#visuals)  
 
 * [.table](#visuals.table) : <code>object</code>
     * [.horizontal(data, ordering)](#visuals.table.horizontal)
@@ -190,9 +245,9 @@ visuals.SpinnerPromise
 #### table.horizontal(data, ordering)
 Notice that you can rename columns by using the CURRENT => NEW syntax in the ordering configuration.
 
-**Kind**: static method of <code>[table](#visuals.table)</code>  
+**Kind**: static method of [<code>table</code>](#visuals.table)  
 **Summary**: Make an horizontal table  
-**Access:** public  
+**Access**: public  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -220,9 +275,9 @@ Notice that you can rename columns by using the CURRENT => NEW syntax in the ord
 
 Vertical tables also accept separators and subtitles, which are represented in the ordering configuration as empty strings and strings surrounded by dollar signs respectively.
 
-**Kind**: static method of <code>[table](#visuals.table)</code>  
+**Kind**: static method of [<code>table</code>](#visuals.table)  
 **Summary**: Make a vertical table  
-**Access:** public  
+**Access**: public  
 
 | Param | Type | Description |
 | --- | --- | --- |
@@ -256,10 +311,10 @@ JOB:       Developer
 ### visuals.drive([message]) ⇒ <code>Promise.&lt;String&gt;</code>
 The dropdown detects and autorefreshes itself when the drive list changes.
 
-**Kind**: static method of <code>[visuals](#visuals)</code>  
+**Kind**: static method of [<code>visuals</code>](#visuals)  
 **Summary**: Prompt the user to select a drive device  
 **Returns**: <code>Promise.&lt;String&gt;</code> - device path  
-**Access:** public  
+**Access**: public  
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |

--- a/build/visuals.js
+++ b/build/visuals.js
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2016 Resin.io
 
@@ -13,11 +12,10 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
- */
-
-/**
- * @namespace visuals
- */
+*/
+   /**
+    * @namespace visuals
+    */
 module.exports = {
   Progress: require('./widgets/progress'),
   Spinner: require('./widgets/spinner'),

--- a/build/widgets/drive/compare.js
+++ b/build/widgets/drive/compare.js
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2016 Resin.io
 
@@ -13,7 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
- */
+*/
 var _, containsDeep, createDiffOperation, differenceDeep;
 
 _ = require('lodash');
@@ -33,7 +32,6 @@ createDiffOperation = function(type, element) {
   };
 };
 
-
 /**
  * @summary Detect changes regarding drives between different time intervals
  * @function
@@ -46,7 +44,6 @@ createDiffOperation = function(type, element) {
  * @example
  * compare(previousDrives, currentDrives)
  */
-
 module.exports = function(previous, current) {
   var additions, mappingAdditions, mappingRemovals, removals;
   additions = differenceDeep(current, previous);

--- a/build/widgets/drive/drive-scanner.js
+++ b/build/widgets/drive/drive-scanner.js
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2016 Resin.io
 
@@ -13,10 +12,8 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
- */
-var DriveScanner, EventEmitter, _, compare,
-  extend = function(child, parent) { for (var key in parent) { if (hasProp.call(parent, key)) child[key] = parent[key]; } function ctor() { this.constructor = child; } ctor.prototype = parent.prototype; child.prototype = new ctor(); child.__super__ = parent.prototype; return child; },
-  hasProp = {}.hasOwnProperty;
+*/
+var DriveScanner, EventEmitter, _, compare;
 
 EventEmitter = require('events').EventEmitter;
 
@@ -24,99 +21,82 @@ _ = require('lodash');
 
 compare = require('./compare');
 
-module.exports = DriveScanner = (function(superClass) {
-  extend(DriveScanner, superClass);
-
-
+module.exports = DriveScanner = class DriveScanner extends EventEmitter {
   /**
-  	 * @summary Dynamically detect changes of connected drives
-  	 * @class
-  	 * @protected
-  	 *
-  	 * @param {Function} driveFinder - drive finder
-  	 * @param {Object} [options] - scan options
-  	 * @param {Number} [options.interval=1000] - interval
-  	 * @param {Object[]} [options.drives] - current drives
-  	 *
-  	 * @example
-  	 * scanner = new DriveScanner driveFinder,
-  	 * 	interval: 1000
-  	 * 	drives: [
-  	 * 		{ foo: 'bar' }
-  	 * 	]
+   * @summary Dynamically detect changes of connected drives
+   * @class
+   * @protected
+   *
+   * @param {Function} driveFinder - drive finder
+   * @param {Object} [options] - scan options
+   * @param {Number} [options.interval=1000] - interval
+   * @param {Object[]} [options.drives] - current drives
+   *
+   * @example
+   * scanner = new DriveScanner driveFinder,
+   * 	interval: 1000
+   * 	drives: [
+   * 		{ foo: 'bar' }
+   * 	]
    */
-
-  function DriveScanner(driveFinder, options) {
-    if (options == null) {
-      options = {};
-    }
-    DriveScanner.__super__.constructor.call(this);
+  constructor(driveFinder, options = {}) {
+    super();
     _.defaults(options, {
       interval: 1000,
       drives: []
     });
     this.drives = options.drives;
-    this.interval = setInterval((function(_this) {
-      return function() {
-        return _this.scan(driveFinder);
-      };
-    })(this), options.interval);
+    this.interval = setInterval(() => {
+      return this.scan(driveFinder);
+    }, options.interval);
     this.scan(driveFinder);
   }
 
+  /**
+   * @summary Broadcast events depending on changes in drive list
+   * @method
+   * @private
+   *
+   * @param {Function} driveFinder - drive finder
+   *
+   * @fires DriveScanner#add
+   * @fires DriveScanner#remove
+   *
+   * @example
+   * scanner = new DriveScanner(@driveFinder, interval: 1000)
+   * scanner.scan(driveFinder)
+   */
+  scan(driveFinder) {
+    return driveFinder().then((drives) => {
+      var comparison;
+      comparison = compare(this.drives, drives);
+      this.drives = comparison.drives;
+      return _.each(comparison.diff, (operation) => {
+        if (operation.type === 'add') {
+          return this.emit('add', operation.drive);
+        } else if (operation.type === 'remove') {
+          return this.emit('remove', operation.drive);
+        } else {
+          throw Error(`Unknown operation: ${operation.type}`);
+        }
+      });
+    });
+  }
 
   /**
-  	 * @summary Broadcast events depending on changes in drive list
-  	 * @method
-  	 * @private
-  	 *
-  	 * @param {Function} driveFinder - drive finder
-  	 *
-  	 * @fires DriveScanner#add
-  	 * @fires DriveScanner#remove
-  	 *
-  	 * @example
-  	 * scanner = new DriveScanner(@driveFinder, interval: 1000)
-  	 * scanner.scan(driveFinder)
+   * @summary Stop the interval
+   * @method
+   * @public
+   *
+   * @example
+   * scanner = new DriveScanner(@driveFinder, interval: 1000)
+   * scanner.stop()
    */
-
-  DriveScanner.prototype.scan = function(driveFinder) {
-    return driveFinder().then((function(_this) {
-      return function(drives) {
-        var comparison;
-        comparison = compare(_this.drives, drives);
-        _this.drives = comparison.drives;
-        return _.each(comparison.diff, function(operation) {
-          if (operation.type === 'add') {
-            return _this.emit('add', operation.drive);
-          } else if (operation.type === 'remove') {
-            return _this.emit('remove', operation.drive);
-          } else {
-            throw Error("Unknown operation: " + operation.type);
-          }
-        });
-      };
-    })(this));
-  };
-
-
-  /**
-  	 * @summary Stop the interval
-  	 * @method
-  	 * @public
-  	 *
-  	 * @example
-  	 * scanner = new DriveScanner(@driveFinder, interval: 1000)
-  	 * scanner.stop()
-   */
-
-  DriveScanner.prototype.stop = function() {
+  stop() {
     if (this.interval == null) {
       throw new Error('Can\'t stop interval. Are you calling stop() with the right context?');
     }
     return clearInterval(this.interval);
-  };
+  }
 
-  return DriveScanner;
-
-})(EventEmitter);
+};

--- a/build/widgets/drive/index.js
+++ b/build/widgets/drive/index.js
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2016 Resin.io
 
@@ -13,7 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
- */
+*/
 var DriveScanner, DynamicList, Promise, _, chalk, driveToChoice, drivelist, getDrives;
 
 _ = require('lodash');
@@ -32,7 +31,7 @@ driveToChoice = function(drive) {
   var size;
   size = drive.size / 1000000000;
   return {
-    name: drive.device + " (" + (size.toFixed(1)) + " GB) - " + drive.description,
+    name: `${drive.device} (${size.toFixed(1)} GB) - ${drive.description}`,
     value: drive.device
   };
 };
@@ -44,7 +43,6 @@ getDrives = function() {
     });
   });
 };
-
 
 /**
  * @summary Prompt the user to select a drive device
@@ -63,11 +61,7 @@ getDrives = function() {
  * visuals.drive('Please select a drive').then (drive) ->
  * 	console.log(drive)
  */
-
-module.exports = function(message) {
-  if (message == null) {
-    message = 'Select a drive';
-  }
+module.exports = function(message = 'Select a drive') {
   return getDrives().then(function(drives) {
     var list, scanner;
     scanner = new DriveScanner(getDrives, {
@@ -76,7 +70,7 @@ module.exports = function(message) {
     });
     list = new DynamicList({
       message: message,
-      emptyMessage: (chalk.red('x')) + " No available drives were detected, plug one in!",
+      emptyMessage: `${chalk.red('x')} No available drives were detected, plug one in!`,
       choices: _.map(drives, driveToChoice)
     });
     scanner.on('add', function(drive) {

--- a/build/widgets/progress.js
+++ b/build/widgets/progress.js
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2016 Resin.io
 
@@ -13,7 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
- */
+*/
 var CARRIAGE_RETURN, Progress, ProgressBarFormatter, _, moment;
 
 _ = require('lodash');
@@ -28,24 +27,23 @@ ProgressBarFormatter = require('progress-bar-formatter');
 
 CARRIAGE_RETURN = '\u001b[1A';
 
-module.exports = Progress = (function() {
-
+module.exports = Progress = class Progress {
   /**
-  	 * @summary Create a CLI Progress Bar
-  	 * @name Progress
-  	 * @class
-  	 * @public
-  	 * @memberof visuals
-  	 *
-  	 * @param {String} message - message
-  	 * @returns {Progress} progress bar instance
-  	 *
-  	 * @throws Will throw if no message.
-  	 *
-  	 * @example
-  	 * progress = new visuals.Progress('Hello World')
+   * @summary Create a CLI Progress Bar
+   * @name Progress
+   * @class
+   * @public
+   * @memberof visuals
+   *
+   * @param {String} message - message
+   * @returns {Progress} progress bar instance
+   *
+   * @throws Will throw if no message.
+   *
+   * @example
+   * progress = new visuals.Progress('Hello World')
    */
-  function Progress(message) {
+  constructor(message) {
     if (_.str.isBlank(message)) {
       throw new Error('Missing message');
     }
@@ -53,59 +51,56 @@ module.exports = Progress = (function() {
     this._bar = new ProgressBarFormatter({
       complete: '=',
       incomplete: ' ',
+      // Width of the progress bar
       length: 24
     });
   }
 
-
   /**
-  	 * @summary Get progress string from a state
-  	 * @name visuals.Progress#_tick
-  	 * @method
-  	 * @private
-  	 *
-  	 * @param {Object} state - progress state
-  	 * @param {Number} state.percentage - percentage
-  	 * @param {Number} [state.eta] - eta in seconds
-  	 *
-  	 * @throws Will throw if no percentage.
-  	 * @throws Will throw if no eta.
-  	 *
-  	 * @returns {String} progress string
-  	 *
-  	 *	@example
-  	 * progress = new visuals.Progress('Hello World')
-  	 * string = progress._tick(percentage: 49, eta: 300)
-  	 * console.log(string)
+   * @summary Get progress string from a state
+   * @name visuals.Progress#_tick
+   * @method
+   * @private
+   *
+   * @param {Object} state - progress state
+   * @param {Number} state.percentage - percentage
+   * @param {Number} [state.eta] - eta in seconds
+   *
+   * @throws Will throw if no percentage.
+   * @throws Will throw if no eta.
+   *
+   * @returns {String} progress string
+   *
+   *	@example
+   * progress = new visuals.Progress('Hello World')
+   * string = progress._tick(percentage: 49, eta: 300)
+   * console.log(string)
    */
-
-  Progress.prototype._tick = function(state) {
+  _tick(state) {
     var bar, percentage;
     if (state.percentage == null) {
       throw new Error('Missing percentage');
     }
     bar = this._bar.format(state.percentage / 100);
     percentage = Math.floor(state.percentage);
-    this._lastLine = this._message + " [" + bar + "] " + percentage + "%";
+    this._lastLine = `${this._message} [${bar}] ${percentage}%`;
     if (state.eta != null) {
-      this._lastLine += " eta " + (moment.duration(state.eta, 'seconds').format('m[m]ss[s]'));
+      this._lastLine += ` eta ${moment.duration(state.eta, 'seconds').format('m[m]ss[s]')}`;
     }
     return this._lastLine;
-  };
-
+  }
 
   /**
-  	 * @summary Erase last printed line
-  	 * @name visuals.Progress#_eraseLastLine
-  	 * @method
-  	 * @private
-  	 *
-  	 * @example
-  	 * progress = new visuals.Progress('Hello World')
-  	 * progress._eraseLastLine()
+   * @summary Erase last printed line
+   * @name visuals.Progress#_eraseLastLine
+   * @method
+   * @private
+   *
+   * @example
+   * progress = new visuals.Progress('Hello World')
+   * progress._eraseLastLine()
    */
-
-  Progress.prototype._eraseLastLine = function() {
+  _eraseLastLine() {
     var eraser;
     if (this._lastLine == null) {
       process.stdout.write('\n');
@@ -113,29 +108,25 @@ module.exports = Progress = (function() {
     }
     eraser = _.str.repeat(' ', this._lastLine.length);
     return console.log(CARRIAGE_RETURN + eraser);
-  };
-
+  }
 
   /**
-  	 * @summary Update the progress bar
-  	 * @name visuals.Progress#update
-  	 * @method
-  	 * @public
-  	 *
-  	 * @param {Object} state - progress state
-  	 * @param {Number} state.percentage - percentage
-  	 * @param {Number} [state.eta] - eta in seconds
-  	 *
-  	 * @example
-  	 * progress = new visuals.Progress('Hello World')
-  	 * progress.update(percentage: 49, eta: 300)
+   * @summary Update the progress bar
+   * @name visuals.Progress#update
+   * @method
+   * @public
+   *
+   * @param {Object} state - progress state
+   * @param {Number} state.percentage - percentage
+   * @param {Number} [state.eta] - eta in seconds
+   *
+   * @example
+   * progress = new visuals.Progress('Hello World')
+   * progress.update(percentage: 49, eta: 300)
    */
-
-  Progress.prototype.update = function(state) {
+  update(state) {
     this._eraseLastLine();
     return console.log(CARRIAGE_RETURN + this._tick(state));
-  };
+  }
 
-  return Progress;
-
-})();
+};

--- a/build/widgets/spinner.js
+++ b/build/widgets/spinner.js
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2016 Resin.io
 
@@ -13,7 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
- */
+*/
 var CliSpinner, Spinner, _;
 
 _ = require('lodash');
@@ -22,73 +21,69 @@ _.str = require('underscore.string');
 
 CliSpinner = require('cli-spinner').Spinner;
 
-module.exports = Spinner = (function() {
-
+module.exports = Spinner = class Spinner {
   /**
-  	 * @summary Create a CLI Spinner
-  	 * @name Spinner
-  	 * @class
-  	 * @public
-  	 * @memberof visuals
-  	 *
-  	 * @param {String} message - message
-  	 * @returns {Spinner} spinner instance
-  	 *
-  	 * @throws Will throw if no message.
-  	 *
-  	 * @example
-  	 * spinner = new visuals.Spinner('Hello World')
+   * @summary Create a CLI Spinner
+   * @name Spinner
+   * @class
+   * @public
+   * @memberof visuals
+   *
+   * @param {String} message - message
+   * @returns {Spinner} spinner instance
+   *
+   * @throws Will throw if no message.
+   *
+   * @example
+   * spinner = new visuals.Spinner('Hello World')
    */
-  function Spinner(message) {
+  constructor(message) {
+    // The message is not strictly necessary
+    // however we require it to force clients
+    // to be descriptive about the on going process
     if (_.str.isBlank(message)) {
       throw new Error('Missing message');
     }
-    this.spinner = new CliSpinner("%s " + message);
+    this.spinner = new CliSpinner(`%s ${message}`);
     this.spinner.setSpinnerString('|/-\\');
     this.spinner.setSpinnerDelay(60);
     this.started = false;
   }
 
-
   /**
-  	 * @summary Start the spinner
-  	 * @name visuals.Spinner#start
-  	 * @method
-  	 * @public
-  	 *
-  	 * @example
-  	 * spinner = new visuals.Spinner('Hello World')
-  	 * spinner.start()
+   * @summary Start the spinner
+   * @name visuals.Spinner#start
+   * @method
+   * @public
+   *
+   * @example
+   * spinner = new visuals.Spinner('Hello World')
+   * spinner.start()
    */
-
-  Spinner.prototype.start = function() {
+  start() {
     if (this.started) {
       return;
     }
     this.spinner.start();
     return this.started = true;
-  };
-
+  }
 
   /**
-  	 * @summary Stop the spinner
-  	 * @name visuals.Spinner#stop
-  	 * @method
-  	 * @public
-  	 *
-  	 * @example
-  	 * spinner = new visuals.Spinner('Hello World')
-  	 * spinner.stop()
+   * @summary Stop the spinner
+   * @name visuals.Spinner#stop
+   * @method
+   * @public
+   *
+   * @example
+   * spinner = new visuals.Spinner('Hello World')
+   * spinner.stop()
    */
-
-  Spinner.prototype.stop = function() {
+  stop() {
     if (!this.started) {
       return;
     }
     this.spinner.stop(true);
     return this.started = false;
-  };
+  }
 
-  return Spinner;
-
-})();
+};

--- a/build/widgets/spinnerpromise.js
+++ b/build/widgets/spinnerpromise.js
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2016 Resin.io
 
@@ -13,7 +12,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
- */
+*/
 var Spinner, SpinnerPromise, _, isPromise;
 
 _ = require('lodash');
@@ -24,65 +23,57 @@ Spinner = require('./spinner');
 
 isPromise = require('is-promise');
 
-module.exports = SpinnerPromise = (function() {
-
+module.exports = SpinnerPromise = class SpinnerPromise {
   /**
-  	 * @summary Create a CLI Spinner that spins on a promise
-  	 * @name SpinnerPromise
-  	 * @class
-  	 * @public
-  	 * @memberof visuals
-  	 *
-  	 * @description
-  	 * This function will start a Spinner and stop it when the
-  	 * passed promise is either fulfilled or rejected. The function
-  	 * returns the passed promise which will be in either rejected or
-  	 * resolved state.
-  	 *
-  	 * @param {Object} options - spinner promise options
-  	 * @param {Promise} options.promise - promise to spin upon
-  	 * @param {String} options.startMessage - start spinner message
-  	 * @param {String} options.stopMessage - stop spinner message
-  	 * @fulfil {Object} value - resolved or rejected promise
-  	 * @returns {Promise}
-  	 *
-  	 * @example
-  	 *  visuals.SpinnerPromise
-  	 *		 promise: scanDevicesPromise
-  	 *		 startMessage: "Scanning devices"
-  	 *		 stopMessage: "Scanned devices"
-  	 *  .then (devices) ->
-  	 *		 console.log devices
+   * @summary Create a CLI Spinner that spins on a promise
+   * @name SpinnerPromise
+   * @class
+   * @public
+   * @memberof visuals
+   *
+   * @description
+   * This function will start a Spinner and stop it when the
+   * passed promise is either fulfilled or rejected. The function
+   * returns the passed promise which will be in either rejected or
+   * resolved state.
+   *
+   * @param {Object} options - spinner promise options
+   * @param {Promise} options.promise - promise to spin upon
+   * @param {String} options.startMessage - start spinner message
+   * @param {String} options.stopMessage - stop spinner message
+   * @fulfil {Object} value - resolved or rejected promise
+   * @returns {Promise}
+   *
+   * @example
+   *  visuals.SpinnerPromise
+   *		 promise: scanDevicesPromise
+   *		 startMessage: "Scanning devices"
+   *		 stopMessage: "Scanned devices"
+   *  .then (devices) ->
+   *		 console.log devices
    */
-  function SpinnerPromise(options) {
+  constructor(options = {}) {
     var clearSpinner, promise, startMessage, stopMessage;
-    if (options == null) {
-      options = {};
-    }
-    promise = options.promise, startMessage = options.startMessage, stopMessage = options.stopMessage;
+    ({promise, startMessage, stopMessage} = options);
     if (!isPromise(promise)) {
       return Promise.reject(new Error("'promise' must be a Promises/A+ compatible promise"));
     }
     if (_.str.isBlank(startMessage)) {
       return Promise.reject(new Error('Missing spinner start message'));
     }
-    clearSpinner = (function(_this) {
-      return function() {
-        var ref;
-        if ((ref = _this.spinner) != null) {
-          ref.stop();
-        }
-        if (stopMessage != null) {
-          console.log(stopMessage);
-        }
-        return promise;
-      };
-    })(this);
+    clearSpinner = () => {
+      var ref;
+      if ((ref = this.spinner) != null) {
+        ref.stop();
+      }
+      if (stopMessage != null) {
+        console.log(stopMessage);
+      }
+      return promise;
+    };
     this.spinner = new Spinner(startMessage);
     this.spinner.start();
     return promise.then(clearSpinner, clearSpinner);
   }
 
-  return SpinnerPromise;
-
-})();
+};

--- a/build/widgets/table.js
+++ b/build/widgets/table.js
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2016 Resin.io
 
@@ -13,7 +12,11 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
- */
+*/
+   /**
+    * @namespace table
+    * @memberof visuals
+    */
 var _, applySubtitles, columnify, getAlias, normalizeSubtitle, normalizeTitle, parseOrdering, trimRight;
 
 _ = require('lodash');
@@ -21,12 +24,6 @@ _ = require('lodash');
 _.str = require('underscore.string');
 
 columnify = require('columnify');
-
-
-/**
- * @namespace table
- * @memberof visuals
- */
 
 parseOrdering = function(ordering, data) {
   return _.compact(_.map(ordering, function(column) {
@@ -65,7 +62,7 @@ normalizeTitle = function(title) {
 };
 
 normalizeSubtitle = function(subtitle, width) {
-  return _.str.rpad("== " + (normalizeTitle(subtitle)), width, ' ');
+  return _.str.rpad(`== ${normalizeTitle(subtitle)}`, width, ' ');
 };
 
 applySubtitles = function(table, ordering) {
@@ -92,7 +89,6 @@ trimRight = function(table) {
   return splitTable.join('\n');
 };
 
-
 /**
  * @summary Make an horizontal table
  * @name visuals.table.horizontal
@@ -118,7 +114,6 @@ trimRight = function(table) {
  * John Doe  40
  * Jane Doe  35
  */
-
 exports.horizontal = function(data, ordering) {
   if (data == null) {
     return;
@@ -132,7 +127,6 @@ exports.horizontal = function(data, ordering) {
     }
   }));
 };
-
 
 /**
  * @summary Make a vertical table
@@ -169,7 +163,6 @@ exports.horizontal = function(data, ordering) {
  * == EXTRAS
  * JOB:       Developer
  */
-
 exports.vertical = function(data, ordering) {
   var orderedData, table;
   if (ordering == null) {
@@ -187,7 +180,15 @@ exports.vertical = function(data, ordering) {
       };
     } else if (column.type === 'subtitle') {
       return {
-        property: "$X$" + index,
+        // We use $X$ to mark titles to be able to replace them later
+        // since including it here as property will result in the title
+        // expanding the column if it's larger than the other properties.
+        // Using $X$ is efficient since there cannot be a case where
+        // other property is surrounded by dollar signs at this point
+        // since it would have been considered a title.
+        // We also use an index after the token to be able to identify
+        // it more easily.
+        property: `$X$${index}`,
         value: null
       };
     }

--- a/package.json
+++ b/package.json
@@ -28,19 +28,19 @@
   "devDependencies": {
     "coffee-script": "^1.9.3",
     "gulp": "^3.9.0",
-    "gulp-coffee": "^2.3.1",
-    "gulp-coffeelint": "^0.5.0",
+    "gulp-coffee": "^3.0.2",
+    "gulp-coffeelint": "^0.6.0",
     "gulp-mocha": "^2.1.3",
-    "gulp-sequence": "^0.4.1",
+    "gulp-sequence": "^1.0.0",
     "gulp-util": "~3.0.1",
-    "jsdoc-to-markdown": "^1.1.1",
-    "mocha": "^2.2.5",
-    "mochainon": "^1.0.0"
+    "jsdoc-to-markdown": "^4.0.1",
+    "mocha": "^5.0.1",
+    "mochainon": "^2.0.0"
   },
   "dependencies": {
-    "bluebird": "^2.9.34",
-    "chalk": "^1.1.1",
-    "cli-spinner": "^0.2.1",
+    "bluebird": "^3.5.1",
+    "chalk": "^2.3.1",
+    "cli-spinner": "0.2.7",
     "columnify": "^1.5.1",
     "drivelist": "^5.0.20",
     "inquirer": "^0.11.0",
@@ -48,7 +48,7 @@
     "is-promise": "^2.1.0",
     "lodash": "^3.10.0",
     "moment": "^2.10.3",
-    "moment-duration-format": "^1.3.0",
+    "moment-duration-format": "^2.2.2",
     "progress-bar-formatter": "^2.0.1",
     "underscore.string": "^3.1.1"
   },


### PR DESCRIPTION
**Dependencies:**

- bluebird 2.9.34 -> 3.5.1
- chalk 1.1.1 -> 2.3.1
- cli-spinner 0.2.1 -> 0.2.7
- moment-duration-format 1.3.0 -> 2.2.2

**NOTE:** Pinned `cli-spinner` to 0.2.7, because 0.2.8 breaks the tests

**Dev-dependencies:**

- gulp-coffee 2.3.1 -> 3.0.2
- gulp-coffeelint 0.5.0 -> 0.6.0
- gulp-sequence 0.4.1 -> 1.0.0
- jsdoc-to-markdown 1.1.1 -> 4.0.1
- mocha 2.2.5 -> 5.0.1
- mochainon 1.0.0 -> 2.0.0

**Packages not updated:**

These dependencies were not updated, as they break the tests,
or cannot be safely determined not to break at this point:

- cli-spinner
- gulp-mocha
- inquirer (can't confirm it doesn't break things)
- lodash
- drivelist (known breaking API changes)

Change-Type: patch
Depends on: #48 