### PR TITLE
Allow updater to specify custom message

### DIFF
--- a/lib/widgets/progress.coffee
+++ b/lib/widgets/progress.coffee
@@ -59,6 +59,7 @@ module.exports = class Progress
 	#
 	# @param {Object} state - progress state
 	# @param {Number} state.percentage - percentage
+	# @param {String} [state.message] - message
 	# @param {Number} [state.eta] - eta in seconds
 	#
 	# @throws Will throw if no percentage.
@@ -79,8 +80,10 @@ module.exports = class Progress
 		bar = @_bar.format(state.percentage / 100)
 		percentage = Math.floor(state.percentage)
 
-		@_lastLine = "#{@_message} [#{bar}] #{percentage}%"
-
+		@_lastLine = "#{@_message}"
+		if state.message?
+			@_lastLine = "#{state.message}"
+		@_lastLine += " [#{bar}] #{percentage}%"
 		if state.eta?
 			@_lastLine += " eta #{moment.duration(state.eta, 'seconds').format('m[m]ss[s]')}"
 
@@ -112,6 +115,7 @@ module.exports = class Progress
 	#
 	# @param {Object} state - progress state
 	# @param {Number} state.percentage - percentage
+	# @parm  {String} [state.message] - message
 	# @param {Number} [state.eta] - eta in seconds
 	#
 	# @example

--- a/tests/widgets/progress.spec.coffee
+++ b/tests/widgets/progress.spec.coffee
@@ -86,3 +86,10 @@ describe 'Progress:', ->
 					].join('')
 
 					m.chai.expect(@stdout.data).to.equal(progress)
+
+				it 'should print progress bar with a new message', ->
+					m.chai.expect(@stdout.data).to.equal('')
+					@progress.update(percentage: 20, eta: 20, message: 'bar')
+
+					progress = '\n\u001b[1Abar [=====                   ] 20% eta 20s\n'
+					m.chai.expect(@stdout.data).to.equal(progress)


### PR DESCRIPTION
The message displayed by the progress bar should be allowed to vary
when the bar is updated.

Change-type: patch
Signed-off-by: Theodor Gherzan <theodor@resin.io>