### PR TITLE
test(ci): Fix Node versions used on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - "8"
   - "6"
-  - "4"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,8 @@ cache:
 # what combinations to test
 environment:
   matrix:
-    - nodejs_version: 0.11
-    - nodejs_version: 0.12
+    - nodejs_version: 8
+    - nodejs_version: 6
 
 install:
   - ps: Install-Product node $env:nodejs_version x64


### PR DESCRIPTION
Due to me previously forgetting about AppVeyor, and that
the updated `coffee-script` dependency doesn't support Node v4 anymore,
here's a followup patch for the Node versions used in CI tests.

Change-Type: patch