### PR TITLE
fix(perf): Avoid blocking writes to stdout in progress

### DIFF
--- a/lib/widgets/progress.coffee
+++ b/lib/widgets/progress.coffee
@@ -105,7 +105,7 @@ module.exports = class Progress
 			return
 
 		eraser = _.str.repeat(' ', @_lastLine.length)
-		console.log(CARRIAGE_RETURN + eraser)
+		process.stdout.write(CARRIAGE_RETURN + eraser + '\n')
 
 	###*
 	# @summary Update the progress bar
@@ -124,4 +124,4 @@ module.exports = class Progress
 	###
 	update: (state) ->
 		@_eraseLastLine()
-		console.log(CARRIAGE_RETURN + @_tick(state))
+		process.stdout.write(CARRIAGE_RETURN + @_tick(state) + '\n')


### PR DESCRIPTION
This uses `process.stdout.write()` directly to avoid blocking I/O
when displaying progress bars in processes that are heavy on I/O,
namely the Etcher CLI.

Change-Type: patch