### PR TITLE
refactor(progress.js): setup moment duration format

### DIFF
--- a/build/widgets/progress.js
+++ b/build/widgets/progress.js
@@ -21,7 +21,7 @@ _.str = require('underscore.string');
 
 moment = require('moment');
 
-require('moment-duration-format');
+require('moment-duration-format')(moment);
 
 ProgressBarFormatter = require('progress-bar-formatter');
 
@@ -112,7 +112,7 @@ module.exports = Progress = class Progress {
       return;
     }
     eraser = _.str.repeat(' ', this._lastLine.length);
-    return console.log(CARRIAGE_RETURN + eraser);
+    return process.stdout.write(CARRIAGE_RETURN + eraser + '\n');
   }
 
   /**
@@ -132,7 +132,7 @@ module.exports = Progress = class Progress {
    */
   update(state) {
     this._eraseLastLine();
-    return console.log(CARRIAGE_RETURN + this._tick(state));
+    return process.stdout.write(CARRIAGE_RETURN + this._tick(state) + '\n');
   }
 
 };

--- a/lib/widgets/progress.coffee
+++ b/lib/widgets/progress.coffee
@@ -17,7 +17,7 @@ limitations under the License.
 _ = require('lodash')
 _.str = require('underscore.string')
 moment = require('moment')
-require('moment-duration-format')
+require('moment-duration-format')(moment)
 ProgressBarFormatter = require('progress-bar-formatter')
 
 CARRIAGE_RETURN = '\u001b[1A'


### PR DESCRIPTION
### Current behavior:

Using this on my old Macbook, the following TypeError occured.

> MacBook Pro (13-inch, Mid 2009)
> OS X El Capitan 10.11.5
> node v6.13.1

```bash
/Users/HAKASHUN/<My-Project>/node_modules/resin-cli-visuals/build/widgets/progress.js:93
this._lastLine += eta ${moment.duration(state.eta, 'seconds').format('m[m]ss[s]')};
^

TypeError: moment.duration(...).format is not a function
at Progress._tick (/Users/HAKASHUN/<My-Project>/node_modules/resin-cli-visuals/build/widgets/progress.js:93:71)
at Progress.update (/Users/HAKASHUN/<My-Project>/node_modules/resin-cli-visuals/build/widgets/progress.js:135:47)
at EventEmitter.writer.on.state (/Users/HAKASHUN/<My-Project>/lib/utils/flash.js:55:42)
at emitOne (events.js:96:13)
at EventEmitter.emit (events.js:188:7)
at Through2.progress (/Users/HAKASHUN/<My-Project>/node_modules/etcher-image-write/lib/index.js:147:17)
at emitOne (events.js:96:13)
at Through2.emit (events.js:188:7)
at emit (/Users/HAKASHUN/<My-Project>/node_modules/progress-stream/index.js:36:6)
at Through2.write [as _transform] (/Users/HAKASHUN/<My-Project>/node_modules/progress-stream/index.js:45:33)
at Through2.Transform._read (_stream_transform.js:167:10)
at Through2.Transform._write (_stream_transform.js:155:12)
at doWrite (_stream_writable.js:333:12)
at writeOrBuffer (_stream_writable.js:319:5)
at Through2.Writable.write (_stream_writable.js:245:11)
at ReadStream.ondata (_stream_readable.js:555:20)
at emitOne (events.js:96:13)
at ReadStream.emit (events.js:188:7)
at readableAddChunk (_stream_readable.js:176:18)
at ReadStream.Readable.push (_stream_readable.js:134:10)
at onread (fs.js:2026:12)
at FSReqWrap.wrapper [as oncomplete] (fs.js:683:17)
```

If it is a relatively new Macbook, no error will occur.

> MacBook Pro (Retina, 15-inch, Mid 2015)
> macOS High Sierra 10.13.1
> node v6.13.1

### About changes

It was because the "moment-duration-format" has not been initialized correctly that I improved the initialization.

https://github.com/jsmreese/moment-duration-format#module
