### PR TITLE
Lazy-load inquirer-dynamic-list and drivelist

### DIFF
--- a/build/widgets/drive/index.js
+++ b/build/widgets/drive/index.js
@@ -13,17 +13,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-var DriveScanner, DynamicList, Promise, _, chalk, driveToChoice, drivelist, getDrives;
+var DriveScanner, Promise, _, chalk, driveToChoice, getDrives;
 
 _ = require('lodash');
 
 chalk = require('chalk');
 
 Promise = require('bluebird');
-
-drivelist = require('drivelist');
-
-DynamicList = require('inquirer-dynamic-list');
 
 DriveScanner = require('./drive-scanner');
 
@@ -37,7 +33,7 @@ driveToChoice = function(drive) {
 };
 
 getDrives = function() {
-  return drivelist.list().then(function(drives) {
+  return require('drivelist').list().then(function(drives) {
     return _.reject(drives, {
       isSystem: true
     });
@@ -63,11 +59,12 @@ getDrives = function() {
  */
 module.exports = function(message = 'Select a drive') {
   return getDrives().then(function(drives) {
-    var list, scanner;
+    var DynamicList, list, scanner;
     scanner = new DriveScanner(getDrives, {
       interval: 1000,
       drives: drives
     });
+    DynamicList = require('inquirer-dynamic-list');
     list = new DynamicList({
       message: message,
       emptyMessage: `${chalk.red('x')} No available drives were detected, plug one in!`,

--- a/lib/widgets/drive/index.coffee
+++ b/lib/widgets/drive/index.coffee
@@ -17,8 +17,6 @@ limitations under the License.
 _ = require('lodash')
 chalk = require('chalk')
 Promise = require('bluebird')
-drivelist = require('drivelist')
-DynamicList = require('inquirer-dynamic-list')
 DriveScanner = require('./drive-scanner')
 
 driveToChoice = (drive) ->
@@ -30,7 +28,7 @@ driveToChoice = (drive) ->
 	}
 
 getDrives = ->
-	drivelist.list().then (drives) ->
+	require('drivelist').list().then (drives) ->
 		return _.reject(drives, isSystem: true)
 
 ###*
@@ -56,6 +54,7 @@ module.exports = (message = 'Select a drive') ->
 			interval: 1000
 			drives: drives
 
+		DynamicList = require('inquirer-dynamic-list')
 		list = new DynamicList
 			message: message
 			emptyMessage: "#{chalk.red('x')} No available drives were detected, plug one in!"


### PR DESCRIPTION
They're rarely used but quite costly to `require`, ~145ms for inquirer-dynamic-list in my test, and ~32ms for drivelist

Change-type: patch