### PR TITLE
Fix the drive widget failing to instantiate the DynamicList

### DIFF
--- a/lib/widgets/drive/index.coffee
+++ b/lib/widgets/drive/index.coffee
@@ -47,7 +47,7 @@ module.exports = (message = 'Select a drive') ->
 	adapter = new scanner.adapters.BlockDeviceAdapter({})
 	scanner = new scanner.Scanner([adapter])
 	Promise.resolve(scanner.start()).then ->
-		DynamicList = require('./dynamic-list')
+		DynamicList = require('./dynamic-list').default
 		list = new DynamicList
 			message: message
 			emptyMessage: "#{chalk.red('x')} No available drives were detected, plug one in!"


### PR DESCRIPTION
Change-type: patch
See: https://balena.zulipchat.com/#narrow/stream/346007-balena-io.2FbalenaCloud/topic/We.20need.20to.20talk.20about.20the.20CLI
See: https://github.com/balena-io-modules/resin-cli-visuals/commit/934e4effb8cb2922dd30d0d30052f7f50ebe4e28#diff-5e2728e21492a7300db94475e26486447e295ff02d65a905bb3adc3110e26657